### PR TITLE
Test and fix buffered streams

### DIFF
--- a/orio/src/buffer.rs
+++ b/orio/src/buffer.rs
@@ -319,12 +319,12 @@ impl<'d, const N: usize, P: Pool<N>> Buffer<'d, N, P> {
 				Ok(())
 			}
 			Allocate::OnError => {
-				if let Err(_) = pool.claim_size(data, count) {
+				if let Err(_) = pool.claim_count(data, seg_count) {
 					data.allocate(seg_count);
 				}
 				Ok(())
 			}
-			Allocate::Never => pool.claim_size(data, count).context(Reserve)
+			Allocate::Never => pool.claim_count(data, seg_count).context(Reserve)
 		}
 	}
 
@@ -378,7 +378,7 @@ impl<'d, const N: usize, P: Pool<N>> Buffer<'d, N, P> {
 
 	/// Skips up to `count` bytes.
 	pub fn skip(&mut self, count: usize) -> usize {
-		if count >= self.count() {
+		if count == self.count() {
 			self.clear();
 			return count
 		}

--- a/orio/src/buffer/write.rs
+++ b/orio/src/buffer/write.rs
@@ -8,7 +8,7 @@ use std::mem::MaybeUninit;
 use std::ops::RangeTo;
 use crate::{Buffer, BufferResult, ResultContext, Seg, StreamResult as Result};
 use crate::BufferContext::{Drain, Fill};
-use crate::streams::{BufSink, BufSource, Sink};
+use crate::streams::{BufSink, Sink, Source};
 use crate::pool::Pool;
 use crate::segment::RBuf;
 use crate::StreamContext::Write;
@@ -45,11 +45,11 @@ impl<'d, const N: usize, P: Pool<N>> Buffer<'d, N, P> {
 
 impl<'d, const N: usize, P: Pool<N>> Sink<'d, N> for Buffer<'d, N, P> {
 	fn drain(&mut self, source: &mut Buffer<'d, N, impl Pool<N>>, count: usize) -> BufferResult<usize> {
-		source.read(self, count).context(Drain)
+		source.fill(self, count).context(Drain)
 	}
 
 	fn drain_all(&mut self, source: &mut Buffer<'d, N, impl Pool<N>>) -> BufferResult<usize> {
-		source.read_all(self).context(Drain)
+		source.fill_all(self).context(Drain)
 	}
 }
 

--- a/orio/src/pool.rs
+++ b/orio/src/pool.rs
@@ -9,7 +9,6 @@ use std::mem::MaybeUninit;
 use std::ops::{DerefMut, Range};
 use std::rc::Rc;
 use std::result;
-use itertools::Itertools;
 use once_cell::sync::Lazy;
 use super::segment::{alloc_block, Block, Seg, SIZE};
 
@@ -181,11 +180,11 @@ impl MutPool for DefaultPool {
 			let Self(vec) = self;
 			let existing_count = count.min(vec.len());
 			let allocate_count = count - existing_count;
+			self.0.extend(Self::allocate(allocate_count));
 			target.extend(
 				self.0
-					.drain(..existing_count)
-					.chain(Self::allocate(allocate_count))
-					.map_into()
+					.drain(..count)
+					.map(Into::into)
 			);
 		}
 	}

--- a/orio/src/streams/hashing.rs
+++ b/orio/src/streams/hashing.rs
@@ -262,20 +262,16 @@ impl<'d, H: Clone + Default + Digest, S: BufSource<'d, N>, const N: usize> BufSo
 		Ok(count)
 	}
 
-	fn read_utf8(&mut self, buf: &mut String, count: usize) -> Result<usize> {
-		let start = buf.len();
-		let count = self.source_mut().read_utf8(buf, count)?;
-		let range = start..start + count.min(buf.len());
-		self.hasher.update(&buf[range]);
-		Ok(count)
+	fn read_utf8<'s>(&mut self, buf: &'s mut String, count: usize) -> Result<&'s str> {
+		let str = self.source_mut().read_utf8(buf, count)?;
+		self.hasher.update(str);
+		Ok(str)
 	}
 
-	fn read_utf8_to_end(&mut self, buf: &mut String) -> Result<usize> {
-		let start = buf.len();
-		let count = self.source_mut().read_utf8_to_end(buf)?;
-		let range = start..start + count.min(buf.len());
-		self.hasher.update(&buf[range]);
-		Ok(count)
+	fn read_utf8_to_end<'s>(&mut self, buf: &'s mut String) -> Result<&'s str> {
+		let str = self.source_mut().read_utf8_to_end(buf)?;
+		self.hasher.update(str);
+		Ok(str)
 	}
 
 	fn read_utf8_line(&mut self, buf: &mut String) -> Result<Utf8Match> {

--- a/orio/tests/buffer.rs
+++ b/orio/tests/buffer.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(round_char_boundary)]
-
 mod dataset;
 
 macro_rules! qc_assert_ok {

--- a/orio/tests/buffered_streams.rs
+++ b/orio/tests/buffered_streams.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![feature(maybe_uninit_slice)]
+
+mod dataset;
+
+use std::mem::MaybeUninit;
+use pretty_assertions::{assert_eq, assert_str_eq};
+use orio::{Buffer, BufferResult, DefaultBuffer, SIZE};
+use orio::pool::Pool;
+use orio::streams::{BufSource, Result, Sink, SourceExt, SinkExt, Stream, BufSink};
+use crate::dataset::{Data, DATASET};
+
+#[test]
+fn read_all() -> Result {
+	const DATA: Data = DATASET.fields_c;
+	let mut source = DATA.buffered();
+	let mut buffer = DefaultBuffer::default();
+	let mut string = String::with_capacity(DATA.size);
+	assert_eq!(source.read_all(&mut buffer)?, DATA.size);
+	assert_str_eq!(buffer.read_utf8_to_end(&mut string)?, DATA.text);
+	Ok(())
+}
+
+#[test]
+fn read() -> Result {
+	const DATA: Data = DATASET.fields_c;
+	let mut source = DATA.buffered();
+	let mut string = String::with_capacity(32);
+	assert_eq!(source.skip(1024)?, 1024);
+	assert_str_eq!(source.read_utf8(&mut string, 32)?, &DATA.text[1024..][..32]);
+	Ok(())
+}
+
+#[derive(Default)]
+struct VecSink {
+	vec: Vec<u8>
+}
+
+impl Stream<SIZE> for VecSink {
+	fn is_closed(&self) -> bool {
+		false
+	}
+
+	fn close(&mut self) -> Result {
+		Ok(())
+	}
+}
+
+impl Sink<'_, SIZE> for VecSink {
+	fn drain(&mut self, source: &mut Buffer<'_, SIZE, impl Pool<SIZE>>, count: usize) -> BufferResult<usize> {
+		let len = self.vec.len();
+		self.vec.reserve(count);
+		let count = source.read_slice(unsafe {
+			MaybeUninit::slice_assume_init_mut(
+				self.vec.spare_capacity_mut()
+			)
+		})?;
+		unsafe {
+			self.vec.set_len(len + count);
+		}
+		Ok(count)
+	}
+}
+
+#[test]
+fn write_all() -> Result {
+	let mut data = DATASET.fields_c;
+	let contents = data.text;
+	let mut sink = VecSink::default().buffered();
+	assert_eq!(sink.write_all(&mut data)?, data.size);
+	let string = String::from_utf8(
+		sink.into_inner().vec
+	).unwrap();
+	assert_str_eq!(&string, contents);
+	Ok(())
+}
+
+#[test]
+fn write() -> Result {
+	let mut data = DATASET.fields_c;
+	let contents = data.text;
+	let mut sink = VecSink::default().buffered();
+	assert_eq!(sink.write(&mut data, 32)?, 32);
+	let string = String::from_utf8(
+		sink.into_inner().vec
+	).unwrap();
+	assert_str_eq!(&string, &contents[..32]);
+	Ok(())
+}

--- a/orio/tests/hash_streams.rs
+++ b/orio/tests/hash_streams.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(round_char_boundary)]
 #![cfg(feature = "sha2")]
 
 mod dataset;


### PR DESCRIPTION
Fixed an infinite loop in buffered wrappers' `read` and `read_all` implementations, caused by 0 bytes being requested.

Fixed a stack overflow in Buffer caused by a cycle of `drain` calling `read` which called `drain`. `drain` was meant to call `fill`.

Buffer::skip reported all bytes skipped when the Buffer is empty, causing no bytes to be skipped in buffered sources.